### PR TITLE
🩹 fix ao ler o código de barras do back-end

### DIFF
--- a/src/components/LixtCartList.js
+++ b/src/components/LixtCartList.js
@@ -62,8 +62,11 @@ export default function LixtCartList({
       // Agrupa os produtos por categorias
       const groupedProducts = selectedList.productsOfList.reduce(
         (accumlator, currentProductOfList) => {
-          accumlator[currentProductOfList.product.category.name] = [
-            ...(accumlator[currentProductOfList.product.category.name] || []),
+          const categoryName =
+            currentProductOfList.product?.category?.name || t('others');
+
+          accumlator[categoryName] = [
+            ...(accumlator[categoryName] || []),
             currentProductOfList,
           ];
           return accumlator;

--- a/src/config/i18n/locales/enUS.js
+++ b/src/config/i18n/locales/enUS.js
@@ -170,4 +170,5 @@ export default {
   readAgain: 'Read again',
   foundBarcode: 'Found barcode',
   addingToList: 'Adding product to the list',
+  others: 'Others',
 };

--- a/src/config/i18n/locales/ptBR.js
+++ b/src/config/i18n/locales/ptBR.js
@@ -169,4 +169,5 @@ export default {
   readAgain: 'Ler novamente',
   foundBarcode: 'Código encontrado',
   addingToList: 'Adicionando produto à lista',
+  others: 'Outros',
 };

--- a/src/screens/ListScreen/ListScreen.js
+++ b/src/screens/ListScreen/ListScreen.js
@@ -318,8 +318,11 @@ export default function ListScreen(props) {
       // Agrupa os produtos por categorias
       const groupedProducts = selectedList.productsOfList.reduce(
         (accumlator, currentProductOfList) => {
-          accumlator[currentProductOfList.product.category.name] = [
-            ...(accumlator[currentProductOfList.product.category.name] || []),
+          const categoryName =
+            currentProductOfList.product?.category?.name || t('others');
+
+          accumlator[categoryName] = [
+            ...(accumlator[categoryName] || []),
             currentProductOfList,
           ];
           return accumlator;


### PR DESCRIPTION
- quando o produto vier com a categoria null deve-se exibí-lo como "outros"