### PR TITLE
🚸  melhorando ux entre tela de novo produto e leitor de código de barras

### DIFF
--- a/src/screens/BarcodeScreen/BarcodeReaderScreen.js
+++ b/src/screens/BarcodeScreen/BarcodeReaderScreen.js
@@ -28,38 +28,50 @@ export default function BarcodeReaderScreen(props) {
 
   const handleBarCodeScanned = async ({ type, data }) => {
     if (allowedBarcodeTypes.includes(type)) {
-      if (!props.route.params?.origin) {
-        setLoading(true);
+      setLoading(true);
 
-        try {
-          const response = await ProductService.getProductByBarcode(data, user);
+      try {
+        const response = await ProductService.getProductByBarcode(data, user);
 
-          if (response.data) {
-            toast.show({
-              title: t('foundBarcode'),
-              description: t('addingToList'),
-              status: 'success',
-            });
-            props.navigation.navigate('Lists', {
-              foundProductByBarcode: response.data,
-            });
-          } else {
-            setNewBarcode(data);
-            setModalOpen(true);
-          }
-        } catch (error) {
-          toast.show({
-            title: t('errorServerDefault'),
-            status: 'warning',
-          });
-        } finally {
-          setLoading(false);
+        // Se a rota de origem for a da tela de novo produto
+        if (props.route.params?.origin) {
+          handleBarcodeForNewProduct(data, response);
         }
-      } else {
-        props.navigation.navigate(props.route.params?.origin, {
-          barcode: data,
+        // Caso for a de listas
+        else {
+          handleBarcodeForLists(data, response);
+        }
+      } catch (error) {
+        toast.show({
+          title: t('errorServerDefault'),
+          status: 'warning',
         });
+      } finally {
+        setLoading(false);
       }
+    }
+  };
+
+  const handleBarcodeForNewProduct = (barcode, response) => {
+    props.navigation.navigate(props.route.params?.origin, {
+      barcode: barcode,
+      foundProductByBarcode: response.data || null, // se o produto já existe no servidor ou não
+    });
+  };
+
+  const handleBarcodeForLists = (barcode, response) => {
+    if (response.data) {
+      toast.show({
+        title: t('foundBarcode'),
+        description: t('addingToList'),
+        status: 'success',
+      });
+      props.navigation.navigate('Lists', {
+        foundProductByBarcode: response.data,
+      });
+    } else {
+      setNewBarcode(barcode);
+      setModalOpen(true);
     }
   };
 

--- a/src/screens/BarcodeScreen/BarcodeReaderScreen.spec.js
+++ b/src/screens/BarcodeScreen/BarcodeReaderScreen.spec.js
@@ -266,6 +266,10 @@ describe('BarcodeReaderScreen component', () => {
         )
       );
 
+      ProductService.getProductByBarcode = jest.fn((path) => {
+        return { data: null };
+      });
+
       // Usamos um botão escondido na tela com a funcionalidade do
       // BarCodeScanner porque o componente original não dispara o
       // evento de leitura no ambiente de testes
@@ -282,6 +286,7 @@ describe('BarcodeReaderScreen component', () => {
 
       expect(navigation.navigate).toHaveBeenCalledWith('NewProduct', {
         barcode: '7891010973902',
+        foundProductByBarcode: null,
       });
     });
   });

--- a/src/screens/NewProductScreen/NewProductScreen.js
+++ b/src/screens/NewProductScreen/NewProductScreen.js
@@ -75,6 +75,15 @@ export default function NewProductScreen(props) {
       if (props.route.params.barcode) {
         setBarcode(props.route.params.barcode);
         props.route.params.barcode = null;
+
+        // Se esse barcode já tiver sido cadastrado anteriormente,
+        // abre o modal de produto duplicado
+        if (props.route.params.foundProductByBarcode) {
+          setDuplicatedModalData({
+            isOpen: true,
+            duplicatedProduct: props.route.params.foundProductByBarcode,
+          });
+        }
       }
     }
   });

--- a/src/screens/NewProductScreen/NewProductScreen.spec.js
+++ b/src/screens/NewProductScreen/NewProductScreen.spec.js
@@ -175,7 +175,65 @@ describe('NewProductScreen component', () => {
         expect(toast).toBeDefined();
       });
 
-      describe('when a product with the same barcode already exists', () => {
+      describe('when the user reads the barcode of a product that already exists', () => {
+        it('should show a modal with a button to add the found product to the list', async () => {
+          const route = {
+            params: {
+              productName: '',
+              barcode: '7891010973902',
+              foundProductByBarcode: {
+                id: 1,
+                name: 'Arroz',
+                userId: null,
+                categoryId: 1,
+                barcode: '7891010973902',
+                measureValue: null,
+                measureType: 'UNITY',
+                category: {
+                  id: 1,
+                  name: 'Alimentação',
+                },
+              },
+            },
+          };
+
+          const renderResults = render(
+            <AuthContext.Provider
+              value={{
+                user: {
+                  id: 1,
+                },
+                login: () => {},
+                logout: () => {},
+              }}
+            >
+              <SafeAreaProvider
+                initialSafeAreaInsets={{ top: 0, left: 0, right: 0, bottom: 0 }}
+              >
+                <NativeBaseProvider>
+                  <NavigationContext.Provider value={navContext}>
+                    <NewProductScreen route={route} navigation={navigation} />
+                  </NavigationContext.Provider>
+                </NativeBaseProvider>
+              </SafeAreaProvider>
+            </AuthContext.Provider>
+          );
+
+          const duplicatedBarcodeModal = await waitFor(() =>
+            renderResults.getByTestId('duplicated-barcode-modal')
+          );
+
+          expect(duplicatedBarcodeModal).toBeDefined();
+
+          const duplicatedBarcodeButton = await waitFor(() =>
+            renderResults.getByTestId('duplicated-barcode-button')
+          );
+
+          expect(duplicatedBarcodeButton).toBeDefined();
+        });
+      });
+
+      describe('when the user tries to register a new product with a barcode that already exists', () => {
         it('should show a modal with a button to add the found product to the list ', async () => {
           const createProductSpy = jest.spyOn(ProductService, 'createProduct');
           createProductSpy.mockReturnValue(


### PR DESCRIPTION
- ao ler um produto que já existe, dispara o modal de produto duplicado ao invés de esperar pra validar somente ao clicar para criar o novo produto