### PR TITLE
🩹 fixes do linter + voltando a mostrar input de marca msm ao ler código de barras.

### DIFF
--- a/src/config/i18n/locales/enUS.js
+++ b/src/config/i18n/locales/enUS.js
@@ -82,6 +82,7 @@ export default {
   productAlreadyOnList: 'The product is already on the list',
   itemWasRemoved: 'Item was removed',
   couldntRemoveItem: "It wasn't possible to remove the item",
+  brandInput: 'Brand(optional)',
 
   edit: 'Edit',
   price: 'Price',

--- a/src/config/i18n/locales/ptBR.js
+++ b/src/config/i18n/locales/ptBR.js
@@ -81,6 +81,7 @@ export default {
   productAlreadyOnList: 'O produto já está na lista',
   itemWasRemoved: 'Item foi removido',
   couldntRemoveItem: 'Não foi possível remover o item',
+  brandInput: 'Marca (opcional)',
 
   edit: 'Editar',
   price: 'Preço',

--- a/src/screens/CartScreen/CartScreen.js
+++ b/src/screens/CartScreen/CartScreen.js
@@ -66,7 +66,9 @@ export default function CartScreen(props) {
       if (selectedList && selectedList?.id === 'view-all') {
         setSelectedList({ id: 'view-all', productsOfList: unifyAllProducts() });
       } else {
-        setSelectedList(lists.find((l) => Number(l.id) === Number(selectedList?.id)));
+        setSelectedList(
+          lists.find((l) => Number(l.id) === Number(selectedList?.id))
+        );
       }
     } else {
       refreshLists();

--- a/src/screens/CartScreen/CartScreen.spec.js
+++ b/src/screens/CartScreen/CartScreen.spec.js
@@ -374,34 +374,36 @@ describe('CartScreen component', () => {
             ownerId: 1,
             owner: 'Fulano',
             description: '',
-            productsOfList: [{
-              id: 13,
-              productId: 3,
-              listId: 2,
-              assignedUserId: null,
-              userWhoMarkedId: 1,
-              name: 'Tomate',
-              isMarked: true,
-              plannedAmount: 10,
-              markedAmount: 2,
-              price: 5,
-              measureValue: null,
-              measureType: 'UNITY',
-              product: {
-                id: 3,
+            productsOfList: [
+              {
+                id: 13,
+                productId: 3,
+                listId: 2,
+                assignedUserId: null,
+                userWhoMarkedId: 1,
                 name: 'Tomate',
-                userId: null,
-                categoryId: 1,
-                barcode: null,
+                isMarked: true,
+                plannedAmount: 10,
+                markedAmount: 2,
+                price: 5,
                 measureValue: null,
                 measureType: 'UNITY',
-                category: {
-                  id: 1,
-                  name: 'Alimentação',
+                product: {
+                  id: 3,
+                  name: 'Tomate',
+                  userId: null,
+                  categoryId: 1,
+                  barcode: null,
+                  measureValue: null,
+                  measureType: 'UNITY',
+                  category: {
+                    id: 1,
+                    name: 'Alimentação',
+                  },
                 },
+                amountComment: 0,
               },
-              amountComment: 0,
-            }],
+            ],
             listMembers: [],
           },
         ];
@@ -537,7 +539,9 @@ describe('CartScreen component', () => {
           (id, value, user) => id
         );
 
-        const inputAmount = await waitFor(() => getByTestId('amount-input-Feijão'));
+        const inputAmount = await waitFor(() =>
+          getByTestId('amount-input-Feijão')
+        );
 
         await waitFor(() => fireEvent(inputAmount, 'change', 2));
 

--- a/src/screens/NewProductScreen/NewProductScreen.js
+++ b/src/screens/NewProductScreen/NewProductScreen.js
@@ -167,18 +167,14 @@ export default function NewProductScreen(props) {
           isInvalid={!!errors.name}
         />
 
-        {
-          !barcode ? (
-            <LixtInput
-              labelName="brand"
-              value={values.brand}
-              onChangeText={handleChange('brand')}
-              onBlur={handleBlur('brand')}
-              inputTestID="new-product-brand"
-              disabled={loading}
-            />
-          ) : null
-        }
+        <LixtInput
+          labelName="brandInput"
+          value={values.brand}
+          onChangeText={handleChange('brand')}
+          onBlur={handleBlur('brand')}
+          inputTestID="new-product-brand"
+          disabled={loading}
+        />
 
         <FormControl my={3}>
           <FormControl.Label>{t('measureType')}</FormControl.Label>


### PR DESCRIPTION
- na tela de NewProductScreen.js input de marca sendo exibido (em qualquer circunstância,)