### PR TITLE
🩹 fix na busca e adição por texto de código de barra

### DIFF
--- a/src/config/i18n/locales/enUS.js
+++ b/src/config/i18n/locales/enUS.js
@@ -202,6 +202,7 @@ export default {
 
   purchaseSaved: 'Purchase saved!',
 
+  barcode: 'Barcode',
   barcodeReader: 'Barcode reader',
   requestForCameraPermission: 'Requesting for camera permission',
   noAccessToCamera: 'No access to camera',

--- a/src/config/i18n/locales/ptBR.js
+++ b/src/config/i18n/locales/ptBR.js
@@ -201,6 +201,7 @@ export default {
 
   purchaseSaved: 'Compra salva!',
 
+  barcode: 'Código de barras',
   barcodeReader: 'Leitor de código de barras',
   requestForCameraPermission: 'Requisitando permissão para câmera',
   noAccessToCamera: 'Sem acesso à câmera',

--- a/src/screens/NewProductScreen/NewProductScreen.js
+++ b/src/screens/NewProductScreen/NewProductScreen.js
@@ -252,7 +252,7 @@ export default function NewProductScreen(props) {
           ) : (
             <HStack justifyContent="space-between" w="100%" alignItems="center">
               <Box>
-                <Text textAlign="left">{t('readValue')}</Text>
+                <Text textAlign="left">{t('barcode')}</Text>
                 <Text textAlign="left">{barcode}</Text>
               </Box>
 

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -10,7 +10,6 @@ const UserService = {
     });
   },
   resetPassword: (email) => {
-    console.log('lang', getI18n().language);
     return BaseService.post(`/auth/forget-password`, email, {
       headers: {
         'Content-Type': 'text/plain',


### PR DESCRIPTION
- busca de códigos por texto não era disparada (só buscava por texto códigos que já estavam no nosso banco)
- ao não encontrar um código de barras e clicar para preencher um produto novo, preenche o campo do form de código de barras com o valor e não o do nome do produto